### PR TITLE
refactor: hardcoded gifCount vervangen door JSON object

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build --configuration production",
+    "start": "sh personalgifs.sh && ng serve",
+    "build": "sh personalgifs.sh && ng build --configuration production",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/personalgifs.sh
+++ b/personalgifs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+gifsDirectory="src/assets/personalgifs"
+outputFilePath="src/assets/personalgifs.json"
+
+# Check if the directory exists
+if [ ! -d "$gifsDirectory" ]; then
+  echo "Directory $gifsDirectory does not exist."
+  exit 1
+fi
+
+# Find all .gif files in the directory
+gifFiles=$(find "$gifsDirectory" -type f -name "*.gif" -exec basename {} \;)
+
+# Create a JSON object
+jsonObject="gifs\":["
+for gif in $gifFiles; do
+  jsonObject+="\"$gif\","
+done
+
+# Remove the trailing comma and close the JSON array
+jsonObject="{\"${jsonObject%,}]}"
+
+# Write the JSON object to the output file
+echo "$jsonObject" > "$outputFilePath"
+
+# Format the JSON file
+jq . "$outputFilePath" > "${outputFilePath}.tmp" && mv "${outputFilePath}.tmp" "$outputFilePath"
+
+echo "Personal GIFs JSON file created at $outputFilePath"

--- a/src/app/services/personal-gif.service.ts
+++ b/src/app/services/personal-gif.service.ts
@@ -1,19 +1,34 @@
 import { Injectable } from '@angular/core';
 import { IGifRetriever } from './igif-retriever';
 import { Observable, of } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class PersonalGifService implements IGifRetriever {
-  private basePath = '/assets/personalgifs/'
-  private gifCount = 21;
+  private basePath = '/assets/personalgifs/';
+  private gifsPath = '/assets/personalgifs.json';
+  private gifs: string[];
 
-  constructor() { }
+  constructor(private http: HttpClient) {
+    this.fetchGifFilenames();
+  }
+
+  private fetchGifFilenames() {
+    this.http
+      .get<{ gifs: string[] }>(this.gifsPath)
+      .subscribe((data) => {
+        this.gifs = data.gifs;
+      });
+  }
 
   retrieveGif(context?: string): Observable<string> {
-    let number = Math.floor(Math.random() * this.gifCount);
-    number = number == 0 ? 1 : number;
-    return of(this.basePath + number + ".gif");
+    if (!this.gifs) {
+      return of('');
+    }
+    const randomIndex = Math.floor(Math.random() * this.gifs.length);
+    const gifUrl = this.basePath + this.gifs[randomIndex];
+    return of(gifUrl);
   }
 }


### PR DESCRIPTION
Hardcoded `gifCount` variabele verwijderd. Het ophalen van gifjes maakt nu gebruik van een JSON object waar alle gif filenames in worden gezet. 

Niemand heeft zin om een JSON bestand aan te passen als er nieuwe gifjes worden toegevoegd dus daar is een bash script voor gemaakt. Zie `personalgifs.sh`

Het script `personalgifs.sh` wordt uitgevoerd bij het maken van een production build en bij het runnen in development mode.

In de toekomst kan je dus ook gewoon de gifjes een naam geven, wel zo handig 